### PR TITLE
#19: Fixed errors when the generated password contains quotes.

### DIFF
--- a/src/RoboFileBase.php
+++ b/src/RoboFileBase.php
@@ -401,7 +401,7 @@ class RoboFileBase extends AbstractRoboFile
               ->dbSuPw($config['password'])
               ->dbPrefix($config['prefix'])
               ->siteName($opts['site-name'])
-              ->accountPass('"' . $passGenerator->generate(16) . '"');
+              ->accountPass('"' . $passGenerator->generateString(16) . '"');
         if ($opts['force']) {
             // There is no force option for drush.
             // $collection->option('force');


### PR DESCRIPTION
The ircmaxell/random-lib package contains 3 different ways of generating a random string. 
* The used `generate()` method creates a string without limiting the containing characters.
* Switching to the `generateString()`method limits the used characters to `0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/`.

See https://github.com/ircmaxell/RandomLib#generator-generatestringlength-characters--