### PR TITLE
Add support to install from existing config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ class RoboFile extends RoboFileBase
             'profile' => 'standard',
             'force-install' => false,
             'config-import' => false,
+            'existing-config' => false,
             'worker' => null,
         ]
     ) {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "boedah/robo-drush": "^3.0",
+        "boedah/robo-drush": "^4.2.0",
         "digipolisgent/robo-digipolis-code-validation": "^0.1.1",
         "digipolisgent/robo-digipolis-helpers": "^0.2",
         "digipolisgent/robo-digipolis-package-drupal8": "^0.1",
@@ -34,6 +34,10 @@
         {
             "name": "Peter Decuyper",
             "email": "peter.decuyper@digipolis.gent"
+        },
+        {
+            "name": "Maarten Segers",
+            "email": "maarten.segers@digipolis.gent"
         }
     ]
 }

--- a/src/RoboFileBase.php
+++ b/src/RoboFileBase.php
@@ -264,6 +264,7 @@ class RoboFileBase extends AbstractRoboFile
             'profile' => 'standard',
             'force-install' => false,
             'config-import' => false,
+            'existing-config' => false,
             'worker' => null,
             'ssh-verbose' => false,
         ]
@@ -465,7 +466,8 @@ class RoboFileBase extends AbstractRoboFile
             ->siteName($opts['site-name'])
             ->accountName($opts['account-name'])
             ->accountMail($opts['account-mail'])
-            ->accountPass('"' . $opts['account-pass'] . '"');
+            ->accountPass('"' . $opts['account-pass'] . '"')
+            ->existingConfig($opts['existing-config']);
 
         if (!empty($config['prefix'])) {
             $drushInstall->dbPrefix($config['prefix']);


### PR DESCRIPTION
Install from config requires boedah/robo-drush:^4.2.0
See https://github.com/boedah/robo-drush/pull/14 

In the upgrade from 3 to 4 this has changed:
accountPass and dbSuPw in site install command are now shell escaped