### PR TITLE
Fix drupal/coder composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "digipolisgent/robo-digipolis-helpers": "^1.0",
         "digipolisgent/robo-digipolis-package-drupal8": "^0.1",
         "digipolisgent/robo-drush": "^4.2.2",
-        "drupal/coder": "^8.2",
         "ircmaxell/random-lib": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "~4.4",
+        "drupal/coder": "^8.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Drupal/coder is a development requirement and does not need to be
installed in projects using robo to deploy Drupal websites.